### PR TITLE
FIX: usunięte zbędne przyciski relacji między stronami

### DIFF
--- a/look/app/mapa/page.tsx
+++ b/look/app/mapa/page.tsx
@@ -479,12 +479,6 @@ export default function MapaPage() {
           )}
         </>
       )}
-
-      <div className="mt-6">
-        <Link href="/szukaj" className="text-blue-600 hover:underline">
-          Przejdź do wyszukiwarki
-        </Link>
-      </div>
     </div>
   );
 }

--- a/look/app/oferta/[id]/page.tsx
+++ b/look/app/oferta/[id]/page.tsx
@@ -196,15 +196,6 @@ export default function OfertaPage({ params }: OfferPageProps) {
             onSuccess={handleQuestionSuccess}
           />
         )}
-
-        <div className="mt-6 text-center">
-          <Link 
-            href="/kalendarz"
-            className="text-main hover:text-green-dark font-medium"
-          >
-            {OFFER_MESSAGES.BACK_TO_CALENDAR}
-          </Link>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
kiedyś jak dodawałem, to miało to wytłumaczenie przechodzenia do kalendarza, teraz z tego kalendarza niewiele korzystam